### PR TITLE
Cache Clearing Mechanisms

### DIFF
--- a/src/middleware/cache.ts
+++ b/src/middleware/cache.ts
@@ -8,8 +8,11 @@ export default (
   return (req, res, next) => {
     const key = `__express__${req.originalUrl || req.url}`;
 
+    const cacheHeader = req.get('Cache-Control');
+    const noCache = cacheHeader === 'no-cache';
+
     const cachedResponse = mcache.get(key);
-    if (cachedResponse) {
+    if (!noCache && cachedResponse) {
       res.send(cachedResponse);
       return; //ensure no next()
     } else {
@@ -21,7 +24,7 @@ export default (
         }
 
         res.end = function(chunk, encoding) {
-          if (res.statusCode !== 200) {
+          if (res.statusCode !== 200 || body.error) {
             // can't cache at this point because everything is stringified by now,
             //  but we also don't know the statusCode until this point. So we cache always
             //  during 'send', but remove during 'end' if we have an error

--- a/src/middleware/cache.ts
+++ b/src/middleware/cache.ts
@@ -1,11 +1,12 @@
 import * as mcache from 'memory-cache';
 import { RequestHandlerParams } from 'express-serve-static-core';
+import { RequestHandler, Request, Response, NextFunction, Send } from 'express';
 
 export default (
   duration: number = 3600000,
   autoRefresh: boolean = false,
-): RequestHandlerParams => {
-  return (req, res, next) => {
+): RequestHandler => {
+  return (req: Request, res: Response, next: NextFunction): any => {
     const key = `__express__${req.originalUrl || req.url}`;
 
     const cacheHeader = req.get('Cache-Control');
@@ -18,20 +19,25 @@ export default (
     } else {
       res.__send = res.send;
 
-      res.send = body => {
+      res.send = (body): Response => {
         if (!res.__end) {
           res.__end = res.end;
         }
 
-        res.end = function(chunk, encoding) {
+        res.end = (
+          chunk?: any | Function,
+          encoding?: string | Function,
+          cb?: Function,
+        ): void => {
           if (res.statusCode !== 200 || body.error) {
             // can't cache at this point because everything is stringified by now,
             //  but we also don't know the statusCode until this point. So we cache always
             //  during 'send', but remove during 'end' if we have an error
             mcache.del(key);
           }
-
-          res.__end(chunk, encoding);
+          if (typeof res.__end !== 'undefined') {
+            res.__end(chunk, encoding, cb);
+          }
         };
 
         // If we don't have something cached, we can cache this response
@@ -42,10 +48,22 @@ export default (
           mcache.put(key, body, duration);
         }
 
-        res.__send(body);
+        if (typeof res.__send !== 'undefined') {
+          res.__send(body);
+        }
+        return res;
       };
 
       next();
     }
   };
+};
+
+export const clear: RequestHandler = (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): any => {
+  mcache.clear();
+  res.status(200).send();
 };

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,6 +5,7 @@ import * as packageJson from '../package.json';
 import logger from './logger';
 import router from './routes/router';
 import cache from './middleware/cache';
+import { clear } from './middleware/cache';
 
 import * as express from 'express';
 import * as cors from 'cors';
@@ -26,6 +27,7 @@ export default () => {
   });
 
   app.use('/v1', cache(), router);
+  app.use('/cache/bust', clear);
 
   router.get('/status', (req, res) =>
     res.send({

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -10,3 +10,14 @@ interface Error {
 interface PropertyCounts {
   [key: string]: number;
 }
+
+declare namespace Express {
+  export interface Response {
+    __send?(body: any): Send;
+    __end?(
+      chunk?: any | Function,
+      encoding?: string | Function,
+      cb?: Function,
+    ): void;
+  }
+}


### PR DESCRIPTION
Adding the header: `cache-control: no-cache` will clear the cache for the specific request.
Calling `/cache/bust` will clear all cached responses.